### PR TITLE
Fix build for kernel 6.16

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -657,7 +657,11 @@ struct rtw_timer_list {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
 static inline void timer_hdl(struct timer_list *in_timer)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+	_timer *ptimer = timer_container_of(ptimer, in_timer, timer);
+#else
 	_timer *ptimer = from_timer(ptimer, in_timer, timer);
+#endif
 
 	ptimer->function(ptimer->arg);
 }


### PR DESCRIPTION
Only compile tested with [kernel 6.16.0-rc4-1-mainline](https://aur.archlinux.org/packages/linux-mainline) on Arch Linux and no warnings/errors appeared.

ref:
https://github.com/torvalds/linux/commit/41cb08555c4164996d67c78b3bf1c658075b75f1