### PR TITLE
Fix compilation on Fedora 43 (kernel 6.17+)

### DIFF
--- a/FEDORA_KERNEL_6.17_FIX.md
+++ b/FEDORA_KERNEL_6.17_FIX.md
@@ -1,0 +1,91 @@
+# Fix for Fedora 43 Kernel 6.17.9
+
+This branch contains fixes to make the rtl8852au driver compile on Fedora 43 with kernel 6.17.9+.
+
+## Problem
+
+The mainline kernel 6.17+ changed the cfg80211 wireless API, adding a `radio_id` parameter to several functions. The original driver doesn't compile on these newer kernels.
+
+## Changes Made
+
+Added `radio_id` parameter to:
+- `cfg80211_rtw_set_wiphy_params()`
+- `cfg80211_rtw_set_txpower()`  
+- `cfg80211_rtw_get_txpower()`
+
+## Installation on Fedora 43
+```bash
+# Install dependencies
+sudo dnf install kernel-devel kernel-headers gcc make git dkms
+
+# Clone this fixed branch
+git clone -b fedora-kernel-6.17-fix https://github.com/andreas-patsalos/rtl8852au.git
+cd rtl8852au
+
+# Compile and install
+make
+sudo make install
+
+# IMPORTANT: Enable USB 3.0 mode for full performance
+sudo bash -c 'echo "options 8852au rtw_switch_usb_mode=1" > /etc/modprobe.d/8852au.conf'
+
+# Reboot
+sudo reboot
+```
+
+## Post-Installation: Performance Optimization
+
+### 1. Verify USB 3.0 Mode
+```bash
+lsusb -t | grep rtl8852au
+# Should show "5000M" not "480M"
+```
+
+### 2. Disable Power Saving
+```bash
+sudo iw dev <your-interface> set power_save off
+```
+
+Make it permanent:
+```bash
+sudo bash -c 'cat > /etc/NetworkManager/dispatcher.d/disable-wifi-powersave << "SCRIPT"
+#!/bin/bash
+if [ "$2" = "up" ]; then
+    /usr/sbin/iw dev $1 set power_save off
+fi
+SCRIPT'
+sudo chmod +x /etc/NetworkManager/dispatcher.d/disable-wifi-powersave
+```
+
+### 3. Connect to 5GHz Network
+For best speeds, use 5GHz band instead of 2.4GHz.
+
+## Supported Devices
+
+Tested on:
+- TP-Link Archer TX20U Plus (USB ID: 2357:013f)
+
+Should work with any RTL8832AU/RTL8852AU chipset adapter.
+
+## Performance Notes
+
+- **USB 3.0 is essential** - Plug into blue USB port
+- Expected speeds: 150-250+ Mbps on 5GHz with good signal
+- USB 2.0 will limit you to ~50 Mbps
+
+## Troubleshooting
+
+**Driver loads but no interface appears:**
+```bash
+sudo modprobe -r 8852au
+sudo modprobe 8852au rtw_switch_usb_mode=1
+```
+
+**Stuck at USB 2.0 speeds:**
+- Make sure you're in a USB 3.0 port (blue plastic inside)
+- Verify `rtw_switch_usb_mode=1` is set in `/etc/modprobe.d/8852au.conf`
+
+## Credits
+
+- Original driver: [natimerry/rtl8852au](https://github.com/natimerry/rtl8852au)
+- Kernel 6.17 fixes: Tested and documented through extensive troubleshooting on Fedora 43

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3436,7 +3436,7 @@ static void cfg80211_rtw_abort_scan(struct wiphy *wiphy,
 }
 #endif /* LINUX_VERSION_CODE >= 4.5.0 */
 
-static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, u32 changed)
+static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, int radio_id, u32 changed)
 {
 #if 0
 	struct iwm_priv *iwm = wiphy_to_iwm(wiphy);
@@ -4414,6 +4414,7 @@ static int cfg80211_rtw_disconnect(struct wiphy *wiphy, struct net_device *ndev,
 static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 	struct wireless_dev *wdev,
+	int radio_id,
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 36)) || defined(COMPAT_KERNEL_RELEASE)
 	enum nl80211_tx_power_setting type, int mbm)
@@ -4454,6 +4455,7 @@ static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
 static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 	struct wireless_dev *wdev,
+	int radio_id,
 	
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0))
 	unsigned int link_id,


### PR DESCRIPTION
Hey, I spent all day getting my TP-Link TX20U Plus working on Fedora 43 and figured I'd share the fixes.

The driver wouldn't compile because kernel 6.17 changed the cfg80211 API - it now needs a `radio_id` parameter in a few functions. I patched:
- cfg80211_rtw_set_wiphy_params()
- cfg80211_rtw_set_txpower()
- cfg80211_rtw_get_txpower()

Tested on Fedora 43 with kernel 6.17.9 and it works great now. Getting 150-250 (vs approx. the 40 i was getting before) Mbps on 5GHz once I figured out the USB 3.0 mode thing (that was a pain to debug).

I also added a guide since the setup has some quirks - mainly the USB 3.0 requirement and power management stuff. Hope this helps someone else avoid the headache I went through!

Hardware: TP-Link Archer TX20U Plus (2357:013f)