### PR TITLE
crypto: rename hmac_sha256() to rtw_hmac_sha256() to fix build on Linux 7.0

### DIFF
--- a/core/crypto/sha256.c
+++ b/core/crypto/sha256.c
@@ -89,7 +89,7 @@ int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 
 
 /**
- * hmac_sha256 - HMAC-SHA256 over data buffer (RFC 2104)
+ * rtw_hmac_sha256 - HMAC-SHA256 over data buffer (RFC 2104)
  * @key: Key for HMAC operations
  * @key_len: Length of the key in bytes
  * @data: Pointers to the data area
@@ -97,7 +97,7 @@ int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
  * @mac: Buffer for the hash (32 bytes)
  * Returns: 0 on success, -1 on failure
  */
-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+int rtw_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
 		size_t data_len, u8 *mac)
 {
 	return hmac_sha256_vector(key, key_len, 1, &data, &data_len, mac);

--- a/core/crypto/sha256.h
+++ b/core/crypto/sha256.h
@@ -13,7 +13,7 @@
 
 int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 		       const u8 *addr[], const size_t *len, u8 *mac);
-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+int rtw_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
 		size_t data_len, u8 *mac);
 int sha256_prf(const u8 *key, size_t key_len, const char *label,
 	       const u8 *data, size_t data_len, u8 *buf, size_t buf_len);


### PR DESCRIPTION
## Problem

`dwa-x1850` HEAD does not build on Linux 7.0:

```
core/crypto/sha256.h:16:5: error: conflicting types for 'hmac_sha256'; have
  'int(const u8 *, size_t,  const u8 *, size_t,  u8 *)'
core/crypto/sha256.c:100:5: error: conflicting types for 'hmac_sha256'; have
  'int(const u8 *, size_t,  const u8 *, size_t,  u8 *)'
make[4]: *** [scripts/Makefile.build:289: core/crypto/sha256.o] Error 1
```

Eric Biggers' `lib/crypto` SHA-256 series made HMAC a first-class part of the
SHA-256 library, adding to `include/crypto/sha2.h`:

```c
void hmac_sha256(const struct hmac_sha256_key *key, const void *data,
                 size_t data_len, u8 out[SHA256_DIGEST_SIZE]);
```

That collides with the driver's wpa_supplicant-derived function of the same name
and incompatible signature:

```c
int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
                size_t data_len, u8 *mac);
```

Both headers land in the same translation unit, so the declarations conflict.

## Fix

Rename the driver's function to `rtw_hmac_sha256()`.

`grep -rnw hmac_sha256` finds exactly three occurrences — a kernel-doc comment,
the definition, and the declaration — and **zero call sites**. Only
`hmac_sha256_vector()` is actually used, by `core/crypto/sha256-prf.c`. The rename
is therefore behaviour-neutral, and because the symbol is driver-internal it needs
no `LINUX_VERSION_CODE` guard — it is safe on every kernel version.

## Reproduction

```
git clone -b dwa-x1850 https://github.com/natimerry/rtl8852au
cd rtl8852au
make -j$(nproc) KVER=$(uname -r)     # on a 7.0 kernel
```

## Verification

Built on Arch Linux, kernel `7.0.14-arch1-1` (x86_64), gcc `16.1.1 20260625`:

| Tree | Result |
|---|---|
| `dwa-x1850` HEAD, unmodified | exit status 2, no module produced |
| `dwa-x1850` HEAD + this commit | exit status 0, **zero errors**, `8852au.ko` built |

`modinfo` on the resulting module reports `vermagic: 7.0.14-arch1-1 SMP preempt
mod_unload`.

This also fixes the AUR `rtl8852au-dkms-git` package, which currently fails to
build on Arch for the same reason.

## Unrelated observation: `radio_id` is not version-gated

Not part of this PR, just something I hit while bisecting. The kernel 6.17
`radio_id` fix already in `dwa-x1850` is applied unconditionally:

```c
static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, int radio_id, u32 changed)
```

`struct cfg80211_ops` only gained that parameter in 6.17, so as written the tree
no longer builds on older kernels. If you want to keep those working, the three
sites (`cfg80211_rtw_set_wiphy_params`, `cfg80211_rtw_set_txpower`,
`cfg80211_rtw_get_txpower`) want:

```c
#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0))
	int radio_id,
#endif
```

Happy to send that as a separate PR if it would be useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xh5tbTQAWbek2feXD2uhaZ
